### PR TITLE
Fix identity and displayId for some objects in the SBOL3 annotation example

### DIFF
--- a/SBOL3/entity/annotation/annotation.nt
+++ b/SBOL3/entity/annotation/annotation.nt
@@ -1,42 +1,43 @@
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://sbols.org/v3#displayId> "usage1" .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/registryStar> "1" .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://sbols.org/v3#name> "BBa_J23119_usage" .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/uses> "442" .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/twinURLs> <https://sbolstandard.org/examples/BBa_J23119/twinParts> .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://sbols.org/v3#description> "BBa_J23119 usage statistics" .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Identified> .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://parts.igem.org/IGEMUsage> .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/twins> "7" .
-<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/inStock> "true" .
-<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/belongsTo> <http://parts.igem.org> .
-<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#role> <https://identifiers.org/SO:0000167> .
-<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#displayId> "BBa_J23119 part" .
-<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#name> "BBa_J23119" .
-<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#description> "Parts J23100 through J23119 are a family of constitutive promoter parts isolated from a small combinatorial library." .
-<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/hasInformation> <https://sbolstandard.org/examples/BBa_J23119/information1> .
-<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
-<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/hasUsage> <https://sbolstandard.org/examples/BBa_J23119/usage1> .
-<https://sbolstandard.org/examples/BBa_J23119> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
-<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/experienceURL> <http://parts.igem.org/Part:BBa_J23119:Experience> .
-<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/group> "iGEM2006_Berkeley" .
-<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://parts.igem.org/twinURL> <http://parts.igem.org/wiki/index.php?title=Part:BBa_M36800> .
-<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://parts.igem.org/twinURL> <http://parts.igem.org/wiki/index.php?title=Part:BBa_M1638> .
-<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://parts.igem.org/twinURL> <http://parts.igem.org/wiki/index.php?title=Part:BBa_J72073> .
-<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://sbols.org/v3#name> "twin parts" .
-<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Identified> .
-<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://sbols.org/v3#displayId> "twinParts" .
-<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://parts.igem.org/TwinPartUsage> .
-<http://parts.igem.org> <http://parts.igem.org/website> "http://parts.igem.org/Main_Page" .
-<http://parts.igem.org> <http://sbols.org/v3#description> "Registry of Standard Biological Parts" .
-<http://parts.igem.org> <http://sbols.org/v3#name> "iGEM Registry" .
-<http://parts.igem.org> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#TopLevel> .
-<http://parts.igem.org> <http://sbols.org/v3#displayId> "parts.igem.org" .
-<http://parts.igem.org> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://parts.igem.org/Repository> .
-<https://sbolstandard.org/examples/BBa_J23119/information1> <http://parts.igem.org/regulation> "//regulation/second_regulation" .
+
+<http://parts.igem.org/repository> <http://parts.igem.org/website> "http://parts.igem.org/Main_Page" .
+<http://parts.igem.org/repository> <http://sbols.org/v3#description> "Registry of Standard Biological Parts" .
+<http://parts.igem.org/repository> <http://sbols.org/v3#displayId> "repository" .
+<http://parts.igem.org/repository> <http://sbols.org/v3#name> "iGEM Registry" .
+<http://parts.igem.org/repository> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://parts.igem.org/Repository> .
+<http://parts.igem.org/repository> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#TopLevel> .
 <https://sbolstandard.org/examples/BBa_J23119/information1> <http://parts.igem.org/regulation> "//regulation/constitutive" .
+<https://sbolstandard.org/examples/BBa_J23119/information1> <http://parts.igem.org/regulation> "//regulation/second_regulation" .
 <https://sbolstandard.org/examples/BBa_J23119/information1> <http://parts.igem.org/sigmaFactor> "//rnap/prokaryote/ecoli/sigma70" .
 <https://sbolstandard.org/examples/BBa_J23119/information1> <http://sbols.org/v3#description> "The experience page captures users' experience using the BBa_J23119 part" .
-<https://sbolstandard.org/examples/BBa_J23119/information1> <http://sbols.org/v3#name> "BBa_J23119_experience" .
-<https://sbolstandard.org/examples/BBa_J23119/information1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Identified> .
 <https://sbolstandard.org/examples/BBa_J23119/information1> <http://sbols.org/v3#displayId> "information1" .
+<https://sbolstandard.org/examples/BBa_J23119/information1> <http://sbols.org/v3#name> "BBa_J23119_experience" .
 <https://sbolstandard.org/examples/BBa_J23119/information1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://parts.igem.org/Information> .
+<https://sbolstandard.org/examples/BBa_J23119/information1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Identified> .
+<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://parts.igem.org/twinURL> <http://parts.igem.org/wiki/index.php?title=Part:BBa_J72073> .
+<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://parts.igem.org/twinURL> <http://parts.igem.org/wiki/index.php?title=Part:BBa_M1638> .
+<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://parts.igem.org/twinURL> <http://parts.igem.org/wiki/index.php?title=Part:BBa_M36800> .
+<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://sbols.org/v3#displayId> "twinParts" .
+<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://sbols.org/v3#name> "twin parts" .
+<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://parts.igem.org/TwinPartUsage> .
+<https://sbolstandard.org/examples/BBa_J23119/twinParts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Identified> .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/inStock> "true" .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/registryStar> "1" .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/twinURLs> <https://sbolstandard.org/examples/BBa_J23119/twinParts> .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/twins> "7" .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://parts.igem.org/uses> "442" .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://sbols.org/v3#description> "BBa_J23119 usage statistics" .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://sbols.org/v3#displayId> "usage1" .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://sbols.org/v3#name> "BBa_J23119_usage" .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://parts.igem.org/IGEMUsage> .
+<https://sbolstandard.org/examples/BBa_J23119/usage1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Identified> .
+<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/belongsTo> <http://parts.igem.org/repository> .
+<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/experienceURL> <http://parts.igem.org/Part:BBa_J23119:Experience> .
+<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/group> "iGEM2006_Berkeley" .
+<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/hasInformation> <https://sbolstandard.org/examples/BBa_J23119/information1> .
+<https://sbolstandard.org/examples/BBa_J23119> <http://parts.igem.org/hasUsage> <https://sbolstandard.org/examples/BBa_J23119/usage1> .
+<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#description> "Parts J23100 through J23119 are a family of constitutive promoter parts isolated from a small combinatorial library." .
+<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#displayId> "BBa_J23119" .
+<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#name> "BBa_J23119" .
+<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#role> <https://identifiers.org/SO:0000167> .
+<https://sbolstandard.org/examples/BBa_J23119> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
+<https://sbolstandard.org/examples/BBa_J23119> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .

--- a/SBOL3/entity/annotation/annotation.rdf
+++ b/SBOL3/entity/annotation/annotation.rdf
@@ -1,65 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
-    xmlns:SO="https://identifiers.org/SO:"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:igem="http://parts.igem.org/"
-    xmlns:EDAM="https://identifiers.org/edam:"
-    xmlns:sbol="http://sbols.org/v3#"
-    xmlns:CHEBI="https://identifiers.org/CHEBI:"
-    xmlns:prov="http://www.w3.org/ns/prov#"
-    xmlns:SBO="https://identifiers.org/SBO:"
-    xmlns:GO="https://identifiers.org/GO:"
-    xmlns="https://sbolstandard.org/examples/"
-    xmlns:om="http://www.ontology-of-units-of-measure.org/resource/om-2/"
-   xml:base="https://sbolstandard.org/examples/">
-   <sbol:Component rdf:about="BBa_J23119">
-      <igem:belongsTo>
-         <sbol:TopLevel rdf:about="http://parts.igem.org">
-            <igem:website>http://parts.igem.org/Main_Page</igem:website>
-            <sbol:description>Registry of Standard Biological Parts</sbol:description>
-            <sbol:name>iGEM Registry</sbol:name>
-            <sbol:displayId>parts.igem.org</sbol:displayId>
-            <rdf:type rdf:resource="http://parts.igem.org/Repository"/>
-         </sbol:TopLevel>
-      </igem:belongsTo>
-      <sbol:role rdf:resource="https://identifiers.org/SO:0000167"/>
-      <sbol:displayId>BBa_J23119 part</sbol:displayId>
-      <sbol:name>BBa_J23119</sbol:name>
-      <sbol:description>Parts J23100 through J23119 are a family of constitutive promoter parts isolated from a small combinatorial library.</sbol:description>
-      <igem:hasInformation>
-         <sbol:Identified rdf:about="BBa_J23119/information1">
-            <igem:regulation>//regulation/second_regulation</igem:regulation>
-            <igem:regulation>//regulation/constitutive</igem:regulation>
-            <igem:sigmaFactor>//rnap/prokaryote/ecoli/sigma70</igem:sigmaFactor>
-            <sbol:description>The experience page captures users' experience using the BBa_J23119 part</sbol:description>
-            <sbol:name>BBa_J23119_experience</sbol:name>
-            <sbol:displayId>information1</sbol:displayId>
-            <rdf:type rdf:resource="http://parts.igem.org/Information"/>
-         </sbol:Identified>
-      </igem:hasInformation>
-      <sbol:type rdf:resource="https://identifiers.org/SBO:0000251"/>
-      <igem:hasUsage>
-         <sbol:Identified rdf:about="BBa_J23119/usage1">
-            <sbol:displayId>usage1</sbol:displayId>
-            <igem:registryStar>1</igem:registryStar>
-            <sbol:name>BBa_J23119_usage</sbol:name>
-            <igem:uses>442</igem:uses>
-            <igem:twinURLs>
-               <sbol:Identified rdf:about="BBa_J23119/twinParts">
-                  <igem:twinURL rdf:resource="http://parts.igem.org/wiki/index.php?title=Part:BBa_M36800"/>
-                  <igem:twinURL rdf:resource="http://parts.igem.org/wiki/index.php?title=Part:BBa_M1638"/>
-                  <igem:twinURL rdf:resource="http://parts.igem.org/wiki/index.php?title=Part:BBa_J72073"/>
-                  <sbol:name>twin parts</sbol:name>
-                  <sbol:displayId>twinParts</sbol:displayId>
-                  <rdf:type rdf:resource="http://parts.igem.org/TwinPartUsage"/>
-               </sbol:Identified>
-            </igem:twinURLs>
-            <sbol:description>BBa_J23119 usage statistics</sbol:description>
-            <rdf:type rdf:resource="http://parts.igem.org/IGEMUsage"/>
-            <igem:twins>7</igem:twins>
-            <igem:inStock>true</igem:inStock>
-         </sbol:Identified>
-      </igem:hasUsage>
-      <igem:experienceURL rdf:resource="http://parts.igem.org/Part:BBa_J23119:Experience"/>
-      <igem:group>iGEM2006_Berkeley</igem:group>
-   </sbol:Component>
+   xmlns:igem="http://parts.igem.org/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:sbol="http://sbols.org/v3#"
+>
+  <rdf:Description rdf:about="https://sbolstandard.org/examples/BBa_J23119">
+    <igem:experienceURL rdf:resource="http://parts.igem.org/Part:BBa_J23119:Experience"/>
+    <igem:group>iGEM2006_Berkeley</igem:group>
+    <sbol:name>BBa_J23119</sbol:name>
+    <igem:hasUsage rdf:resource="https://sbolstandard.org/examples/BBa_J23119/usage1"/>
+    <sbol:role rdf:resource="https://identifiers.org/SO:0000167"/>
+    <igem:belongsTo rdf:resource="http://parts.igem.org/repository"/>
+    <sbol:displayId>BBa_J23119</sbol:displayId>
+    <igem:hasInformation rdf:resource="https://sbolstandard.org/examples/BBa_J23119/information1"/>
+    <sbol:type rdf:resource="https://identifiers.org/SBO:0000251"/>
+    <sbol:description>Parts J23100 through J23119 are a family of constitutive promoter parts isolated from a small combinatorial library.</sbol:description>
+    <rdf:type rdf:resource="http://sbols.org/v3#Component"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://parts.igem.org/repository">
+    <rdf:type rdf:resource="http://parts.igem.org/Repository"/>
+    <rdf:type rdf:resource="http://sbols.org/v3#TopLevel"/>
+    <igem:website>http://parts.igem.org/Main_Page</igem:website>
+    <sbol:name>iGEM Registry</sbol:name>
+    <sbol:displayId>repository</sbol:displayId>
+    <sbol:description>Registry of Standard Biological Parts</sbol:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://sbolstandard.org/examples/BBa_J23119/twinParts">
+    <igem:twinURL rdf:resource="http://parts.igem.org/wiki/index.php?title=Part:BBa_M36800"/>
+    <rdf:type rdf:resource="http://parts.igem.org/TwinPartUsage"/>
+    <sbol:displayId>twinParts</sbol:displayId>
+    <igem:twinURL rdf:resource="http://parts.igem.org/wiki/index.php?title=Part:BBa_M1638"/>
+    <igem:twinURL rdf:resource="http://parts.igem.org/wiki/index.php?title=Part:BBa_J72073"/>
+    <rdf:type rdf:resource="http://sbols.org/v3#Identified"/>
+    <sbol:name>twin parts</sbol:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://sbolstandard.org/examples/BBa_J23119/information1">
+    <igem:sigmaFactor>//rnap/prokaryote/ecoli/sigma70</igem:sigmaFactor>
+    <sbol:displayId>information1</sbol:displayId>
+    <rdf:type rdf:resource="http://sbols.org/v3#Identified"/>
+    <igem:regulation>//regulation/second_regulation</igem:regulation>
+    <rdf:type rdf:resource="http://parts.igem.org/Information"/>
+    <igem:regulation>//regulation/constitutive</igem:regulation>
+    <sbol:description>The experience page captures users' experience using the BBa_J23119 part</sbol:description>
+    <sbol:name>BBa_J23119_experience</sbol:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://sbolstandard.org/examples/BBa_J23119/usage1">
+    <igem:twins>7</igem:twins>
+    <sbol:description>BBa_J23119 usage statistics</sbol:description>
+    <igem:registryStar>1</igem:registryStar>
+    <rdf:type rdf:resource="http://parts.igem.org/IGEMUsage"/>
+    <igem:uses>442</igem:uses>
+    <rdf:type rdf:resource="http://sbols.org/v3#Identified"/>
+    <sbol:name>BBa_J23119_usage</sbol:name>
+    <igem:twinURLs rdf:resource="https://sbolstandard.org/examples/BBa_J23119/twinParts"/>
+    <igem:inStock>true</igem:inStock>
+    <sbol:displayId>usage1</sbol:displayId>
+  </rdf:Description>
 </rdf:RDF>

--- a/SBOL3/entity/annotation/annotation.ttl
+++ b/SBOL3/entity/annotation/annotation.ttl
@@ -21,13 +21,13 @@
         sbol:name          "BBa_J23119_usage" .
 
 :BBa_J23119  a               sbol:Component ;
-        igem:belongsTo       <http://parts.igem.org> ;
+        igem:belongsTo       <http://parts.igem.org/repository> ;
         igem:experienceURL   igem:Part:BBa_J23119:Experience ;
         igem:group           "iGEM2006_Berkeley" ;
         igem:hasInformation  <BBa_J23119/information1> ;
         igem:hasUsage        <BBa_J23119/usage1> ;
         sbol:description     "Parts J23100 through J23119 are a family of constitutive promoter parts isolated from a small combinatorial library." ;
-        sbol:displayId       "BBa_J23119 part" ;
+        sbol:displayId       "BBa_J23119" ;
         sbol:name            "BBa_J23119" ;
         sbol:role            SO:0000167 ;
         sbol:type            SBO:0000251 .
@@ -38,11 +38,11 @@
         sbol:displayId  "twinParts" ;
         sbol:name       "twin parts" .
 
-<http://parts.igem.org>
+<http://parts.igem.org/repository>
         a                 sbol:TopLevel , igem:Repository ;
         igem:website      "http://parts.igem.org/Main_Page" ;
         sbol:description  "Registry of Standard Biological Parts" ;
-        sbol:displayId    "parts.igem.org" ;
+        sbol:displayId    "repository" ;
         sbol:name         "iGEM Registry" .
 
 <BBa_J23119/information1>


### PR DESCRIPTION
Fix the identity of the igem repository so that it conforms to the
rules of SBOL 3 section 5.1. Make displayId of both the repository and
BBa_J23119. The latter had a space in the displayId, which is not
allowed, and which did not match the displayId portion of the
identity.

Fixes #22 